### PR TITLE
Fix tiny issue in readme and add support for video podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A program for managing & catching podcasts from the terminal.
 Work in Progress and unfinished. Use at your own risk.
 ## Requirements
 requires feedparser, pycurl and colorama  
-Ubuntu: ```sudo apt-get install python3-colorama python3-feedparser python3-pycurl```
+Ubuntu: ```sudo apt-get install python3-colorama python3-feedparser python3-pycurl python3-docopt```
 
 ## Configuration
 

--- a/podfox.py
+++ b/podfox.py
@@ -40,6 +40,11 @@ from time import mktime
 
 CONFIGURATION = {}
 
+mimetypes = [
+    'audio/ogg',
+    'audio/mpeg',
+    'video/mp4'
+]
 
 def print_err(err):
     print(Fore.RED + Style.BRIGHT + err +
@@ -160,8 +165,7 @@ def episodes_from_feed(d):
             for link in entry.links:
                 if not hasattr(link, 'type'):
                     continue
-                if hasattr(link, 'type') and (link.type == 'audio/mpeg' or
-                                              link.type == 'audio/ogg'):
+                if hasattr(link, 'type') and (link.type in mimetypes):
                     if hasattr(entry, 'title'):
                         episode_title = entry.title
                     else:


### PR DESCRIPTION
Thanks for creating this, it fit my needs almost exactly!

Almost all the podcasts I subscribe to are video, so the mimetype limit was a real issue.

I created a mimetypes list object at the top of the code that can hold a list of all acceptable mimetypes and then edited the check to a simple "link.type in mimetypes". This way it can also be easily expanded by just throwing more items in the list.

Your readme was great on getting started (not that it needed much of one to get started), the only thing really missing was you left off one of the dependencies: python3-docopt

There may be more pull requests coming later as I look over the code more deeply, but I love what I see so far!