### PR TITLE
Add functionality for specifying an alternate config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Here is mine:
 ```
 {
     "podcast-directory" : "/home/basti/podcasts",
-    "maxnum"            : 5
+    "maxnum"            : 5,
+    "maxthreads"        : 2
 }
 ```
 `podcast-directory` is your main directory to store podcast data. This directory should be empty before you

--- a/podfox.py
+++ b/podfox.py
@@ -11,7 +11,7 @@ Usage:
     podfox.py rename <shortname> <newname> [-c=<path>]
 
 Options:
-    -c --config=<path>    Specify an alternate config file [default: ~/.podfox.json ]
+    -c --config=<path>    Specify an alternate config file [default: ~/.podfox.json]
     -h --help     Show this help
 """
 # (C) 2015 Bastian Reitemeier
@@ -21,6 +21,7 @@ from colorama import Fore, Back, Style
 from docopt import docopt
 from os.path import expanduser
 from sys import exit
+from threading import Thread
 import colorama
 import feedparser
 import json
@@ -187,11 +188,23 @@ def download_multiple(feed, maxnum):
             break
         if not episode['downloaded']:
         #TODO: multithreading
-            download_single(feed['shortname'], episode['url'])
+            downloadthread = download_thread(feed['shortname'], episode['url'])
+            downloadthread.start()
+            #download_single(feed['shortname'], episode['url'])
             episode['downloaded'] = True
             maxnum -= 1
     overwrite_config(feed)
 
+
+class download_thread(Thread):
+    def __init__(self, folder, url):
+        Thread.__init__(self)
+
+        self.folder = folder
+        self.url = url
+
+    def run(self):
+        download_single(self.folder, self.url)
 
 def download_single(folder, url):
     base = CONFIGURATION['podcast-directory']
@@ -206,7 +219,7 @@ def download_single(folder, url):
         c.setopt(c.FOLLOWLOCATION, True)
         c.perform()
         c.close()
-    print("done.")
+    print("{:s} done.".format(filename))
 
 
 def available_feeds():

--- a/podfox.py
+++ b/podfox.py
@@ -3,14 +3,15 @@
 
 
 Usage:
-    podfox.py import <feed-url> [<shortname>]
-    podfox.py update [<shortname>]
-    podfox.py feeds
-    podfox.py episodes <shortname>
-    podfox.py download [<shortname> --how-many=<n>]
-    podfox.py rename <shortname> <newname>
+    podfox.py import <feed-url> [<shortname>] [-c=<path>]
+    podfox.py update [<shortname>] [-c=<path>]
+    podfox.py feeds [-c=<path>]
+    podfox.py episodes <shortname> [-c=<path>]
+    podfox.py download [<shortname> --how-many=<n>] [-c=<path>]
+    podfox.py rename <shortname> <newname> [-c=<path>]
 
 Options:
+    -c --config=<path>    Specify an alternate config file [default: ~/.podfox.json ]
     -h --help     Show this help
 """
 # (C) 2015 Bastian Reitemeier
@@ -273,8 +274,9 @@ if __name__ == '__main__':
     arguments = docopt(__doc__, version='p0d 0.01')
     # before we do anything with the commands,
     # find the configuration file
-    home_directory = expanduser("~")
-    with open(home_directory + '/.podfox.json') as conf_file:
+    configfile = expanduser(arguments["--config"])
+
+    with open(configfile) as conf_file:
         try:
             CONFIGURATION = json.load(conf_file)
         except ValueError:

--- a/podfox.py
+++ b/podfox.py
@@ -40,6 +40,11 @@ from time import mktime
 
 CONFIGURATION = {}
 
+mimetypes = [
+    'audio/ogg',
+    'audio/mpeg',
+    'video/mp4'
+]
 
 def print_err(err):
     print(Fore.RED + Style.BRIGHT + err +
@@ -160,8 +165,7 @@ def episodes_from_feed(d):
             for link in entry.links:
                 if not hasattr(link, 'type'):
                     continue
-                if hasattr(link, 'type') and (link.type == 'audio/mpeg' or
-                                              link.type == 'audio/ogg'):
+                if hasattr(link, 'type') and (link.type in mimetypes):
                     if hasattr(entry, 'title'):
                         episode_title = entry.title
                     else:


### PR DESCRIPTION
Not 100% on understanding docopt, but liking it so far (once you get used to it, it's a really nice way to build an argument parser).

I'm personally implementing this on a NAS server and have significantly separate locations for Audio and Video, so I wanted the ability to specify an alternate config file.

Config still defaults to ~/.podfox.json when unspecified, but can now specify an alternate file with an optional -c

With this change, it now perfectly meets my needs :-)