### PR TITLE
Fixed issue where requests would raise an InvalidSchema exception for…

### DIFF
--- a/podfox/__init__.py
+++ b/podfox/__init__.py
@@ -205,7 +205,7 @@ def download_single(folder, url):
     filename = url.split('/')[-1]
     filename = filename.split('?')[0]
     print_green("{:s} downloading".format(filename))
-    r = requests.get(url, stream=True)
+    r = requests.get(url.strip(), stream=True)
     with open(os.path.join(base, folder, filename), 'wb') as f:
         for chunk in r.iter_content(chunk_size=1024**2):
             f.write(chunk)


### PR DESCRIPTION
Hi, there
This is a pretty small fix, but I've noticed that some feeds I'm subscribed to leave extraneous whitespace in their URL sections, which requests doesn't like. Since I'm probably not the only one to have this issue, I decided that I'd submit the fix as a pull request.

For those interested, the exception raised was
`Traceback (most recent call last):
  File "/usr/bin/podfox", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python3.6/site-packages/podfox/__init__.py", line 337, in main
    download_multiple(feed, maxnum)
  File "/usr/lib/python3.6/site-packages/podfox/__init__.py", line 196, in download_multiple
    download_single(feed['shortname'], episode['url'])
  File "/usr/lib/python3.6/site-packages/podfox/__init__.py", line 208, in download_single
    r = requests.get(url, stream=True)
  File "/usr/lib/python3.6/site-packages/requests/api.py", line 70, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/lib/python3.6/site-packages/requests/api.py", line 56, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 590, in send
    adapter = self.get_adapter(url=request.url)
  File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 672, in get_adapter
    raise InvalidSchema("No connection adapters were found for '%s'" % url)
requests.exceptions.InvalidSchema: No connection adapters were found for ' http://cdn.mega64.com/mega64podcast432.mp3'`