### PR TITLE
take filename from content-disposition header if present

### DIFF
--- a/podfox/__init__.py
+++ b/podfox/__init__.py
@@ -28,6 +28,7 @@ import os
 import os.path
 import requests
 import sys
+import re
 
 # RSS datetimes follow RFC 2822, same as email headers.
 # this is the chain of stackoverflow posts that led me to believe this is true.
@@ -202,10 +203,13 @@ def download_multiple(feed, maxnum):
 def download_single(folder, url):
     print(url)
     base = CONFIGURATION['podcast-directory']
-    filename = url.split('/')[-1]
-    filename = filename.split('?')[0]
-    print_green("{:s} downloading".format(filename))
     r = requests.get(url.strip(), stream=True)
+    try:
+        filename=re.findall('filename="([^"]+)',r.headers['content-disposition'])[0]
+    except:
+        filename = url.split('/')[-1]
+        filename = filename.split('?')[0]
+    print_green("{:s} downloading".format(filename))
     with open(os.path.join(base, folder, filename), 'wb') as f:
         for chunk in r.iter_content(chunk_size=1024**2):
             f.write(chunk)
@@ -278,6 +282,7 @@ def pretty_print_episodes(feed):
 
 
 def main():
+    global CONFIGURATION
     colorama.init()
     arguments = docopt(__doc__, version='p0d 0.01')
     # before we do anything with the commands,


### PR DESCRIPTION
Take filename from content-disposition header if it's set. This is useful on BBC Podcasts, where the filename in the RSS feed is something random and hence useless such as p055flz6.mp3. This means you end up with a bunch of files that you can't tell what's what without examining metadata. But the BBC put a meaningful filename, such as MoreOrLessBehindTheStats-20170612-WSMoreOrLessAreAfricanFootballPlayersMoreLikelyToDieOnTheField.mp3, in the content-disposition header.

The version of podfox I've been installed via pip has "global CONFIGURATION" in main(), but the version I pulled from git didn't have that and didn't work for me until I added it.

My python skills are rudimentary at best and this is the first time I've used GitHub, so I hope I'm doing all this correctly it is at least somewhat useful!