### PR TITLE
Add optional progress bar for downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.swp
+.env/
+.vscode/
+**/__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 colorama==0.3.7
 docopt==0.6.2
 feedparser==5.2.1
+progress==1.5
 requests==2.20.0


### PR DESCRIPTION
Previously, when downloading new episodes the script only printed the URL of the current download and provided no ongoing output. These changes cause a basic progress bar to appear as new episodes are downloaded. I used the `progress` module (see [PyPI](https://pypi.org/project/progress/)), which made this pretty simple. Note that the progress bar only appears if the user passes `--show-progress` or `-p`.

For example, downloading the latest episode of [Back to Work](http://5by5.tv/b2w):

```
(.env) bradley@enterprise ~/c/podfox> podfox download B2W --how-many 1 --show-progress
b2w-484.mp3 |████████████████████████| 51.9 / 51.9 MB  (4.01 MB/s)
```

I changed the chunk size to 128 kB from 1024 kB so the progress bar output could be a bit more precise. I haven't noticed any speed issues as a result.

Fixes #1