### PR TITLE
Add single `fetch` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In podfox, every podcast is identified with its own `shortname`, which is restri
     podfox.py feeds
     podfox.py episodes <shortname>
     podfox.py download [<shortname> --how-many=<n>]
+    podfox.py fetch [<shortname> --how-many=<n>]
 ```
 ### Import 
 
@@ -107,3 +108,7 @@ Extortion Startups | TechSNAP 229         |  Not Downloaded
 
 `podfox download ts --how-many=3` will download the 3 newest techsnap podcasts that have not yet been downloaded. (Skipping newer, but already downloaded ones). If the `--how-many` parameter is omitted, the `maxnum` parameter from the configuration file is used instead.
 
+### Fetch
+
+`podfox fetch` will go through the `update` and `download` processes together,
+allowing the user to run both with a single command.

--- a/podfox/__init__.py
+++ b/podfox/__init__.py
@@ -8,6 +8,7 @@ Usage:
     podfox.py feeds [-c=<path>]
     podfox.py episodes <shortname> [-c=<path>]
     podfox.py download [<shortname> --how-many=<n>] [-c=<path>]
+    podfox.py fetch [<shortname> --how-many=<n>] [-c=<path>]
     podfox.py rename <shortname> <newname> [-c=<path>]
 
 Options:
@@ -373,6 +374,29 @@ def main():
         #download episodes for all feeds.
         else:
             for feed in available_feeds():
+                download_multiple(feed,  maxnum)
+            exit(0)
+    if arguments['fetch']:
+        if arguments['--how-many']:
+            maxnum = int(arguments['--how-many'])
+        else:
+            maxnum = CONFIGURATION['maxnum']
+        #download episodes for a specific feed
+        if arguments['<shortname>']:
+            feed = find_feed(arguments['<shortname>'])
+            if feed:
+                print_green('updating and downloading {}'.format(feed['title']))
+                update_feed(feed)
+                download_multiple(feed, maxnum)
+                exit(0)
+            else:
+                print_err("feed {} not found".format(arguments['<shortname>']))
+                exit(-1)
+        #download episodes for all feeds.
+        else:
+            for feed in available_feeds():
+                print_green('updating and downloading {}'.format(feed['title']))
+                update_feed(feed)
                 download_multiple(feed,  maxnum)
             exit(0)
     if arguments['rename']:


### PR DESCRIPTION
This PR adds a new command, `fetch` to Podfox. `fetch` is a combination of `update` and `download`, allowing both to happen in a single command. It maintains the command line arguments from both the `update` and `download` commands, allowing it to operate exactly the same as before, just condensing everything into a single command.