### PR TITLE
Allow usage of later versions of feedparser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorama==0.3.7
 docopt==0.6.2
-feedparser==5.2.1
+feedparser>=5.2.1
 requests==2.20.0


### PR DESCRIPTION
Having feedparser locked to 5.2.1 causes issues with python 3.9.
This allows usage with versions of feedparser >=5.2.1