### PR TITLE
Update feedparser version for py39

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorama==0.3.7
 docopt==0.6.2
-feedparser==5.2.1
+feedparser==6.0.2
 requests==2.20.0


### PR DESCRIPTION
Python3.9 removes the `base64.encodingstring` and `base64.decodestring`
after being deprecated in an earlier version.  Update feedparser to a
version that doesn't reference these functions so that we don't crash on
python3.9.