### PR TITLE
Upgrade feedparser to version 6.0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorama==0.3.7
 docopt==0.6.2
-feedparser==6.0.2
+feedparser==6.0.8
 requests==2.20.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='podfox',
     install_requires=[
         'colorama==0.3.7',
         'docopt==0.6.2',
-        'feedparser==5.2.1',
+        'feedparser==6.0.8',
         'requests==2.20.0',
         ],
     )


### PR DESCRIPTION
Relates to #38 

Upgrades feedparser to version 6.0.8. This version supports Python:
* 3.6
* 3.7
* 3.8
* 3.9

And allows podfox to install correctly using setup.py 

ref: https://pypi.org/project/feedparser/6.0.8/