### PR TITLE
Updated to work on py3.11

### DIFF
--- a/podfox/__init__.py
+++ b/podfox/__init__.py
@@ -45,6 +45,7 @@ from time import mktime
 CONFIGURATION_DEFAULTS = {
     "podcast-directory": "~/Podcasts",
     "maxnum": 5000,
+    "maxage-days" : 356,
     "mimetypes": [ "audio/aac",
                    "audio/ogg",
                    "audio/mpeg",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorama==0.3.7
 docopt==0.6.2
 feedparser==6.0.2
-requests==2.20.0
+requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-colorama==0.3.7
-docopt==0.6.2
-feedparser==6.0.2
-requests==2.31.0
+colorama>=0.3.7
+docopt>=0.6.2
+feedparser>=6.0.2
+requests>=2.31.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(name='podfox',
         'colorama==0.3.7',
         'docopt==0.6.2',
         'feedparser==5.2.1',
-        'requests==2.20.0',
+        'requests==2.31.0',
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('requirements.txt') as f:
     required = f.read().splitlines()
 
 setup(name='podfox',
-    version='0.1.1',
+    version='0.1.2',
     description='Podcatcher for the terminal',
     url='http://github.com/brtmr/podfox',
     author='Bastian Reitemeier',
@@ -18,9 +18,9 @@ setup(name='podfox',
         ]
     },
     install_requires=[
-        'colorama==0.3.7',
-        'docopt==0.6.2',
-        'feedparser==5.2.1',
-        'requests==2.31.0',
+        'colorama>=0.3.7',
+        'docopt>=0.6.2',
+        'feedparser>=6.0.2',
+        'requests>=2.31.0',
         ],
     )


### PR DESCRIPTION
fwiw: dependabot didn't update the setup.py in its branch. So I did that and bumped version='0.1.2', you might not agree with that, but it would make it easier for pip to distinguish the version differences.

I also added `maxage-days` in `CONFIGURATION_DEFAULTS`, which, if not present in the user config would segfault.

I have tested this on a vanilla python:3.11 docker container with the following versions installed by default.

### Tested with 
| package | version |
|---|---|
|colorama        |   0.4.6|
|docopt            | 0.6.2|
|feedparser       |  6.0.10| 
|requests          | 2.31.0 |
|urllib3           | 2.0.4 |

Thanks for this project,  use it everyday :) 